### PR TITLE
Implement dynamic fit-to-window scaling

### DIFF
--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -1369,10 +1369,13 @@ image-rendering: pixelated;
       }
       document.body.appendChild(canvas);
       const cs = 95;
-      const cw = canvasSize.x >= canvasSize.y ? cs : (cs / canvasSize.y) * canvasSize.x;
-      const ch = canvasSize.y >= canvasSize.x ? cs : (cs / canvasSize.x) * canvasSize.y;
-      canvas.style.width = `${cw}vmin`;
-      canvas.style.height = `${ch}vmin`;
+      const wr = innerWidth/innerHeight;
+      const cr = canvasSize.x/canvasSize.y;
+      const unit = (wr >= cr) ? "vh" : "vw";
+      const cw = (cr >= wr) ? cs : cs * canvasSize.x / canvasSize.y;
+      const ch = (wr >= cr) ? cs : cs * canvasSize.y / canvasSize.x;
+      canvas.style.width = `${cw}${unit}`;
+      canvas.style.height = `${ch}${unit}`;
       if (isCapturing) {
           captureCanvas = document.createElement("canvas");
           if (canvasSize.x <= canvasSize.y * 2) {


### PR DESCRIPTION
# Problem

Incorrect scaling when the canvas size is not of ratio 1:1 and the browser window size is in portrait mode (window height is larger than window width, which is common on mobile devices).

To replicate, simply run a game on a non-1:1 ratio (e.g. `options = {viewSize: { x: 80, y: 120}}`) in a non-square window size. The following image is an example of the problem (captured on Firefox Inspector set to iPhone 6/7/8), in which the canvas width should have be maximized to the window width, but did not.

![DynamicDuo_iphone678_before](https://user-images.githubusercontent.com/5671813/124592697-4dfcc480-de90-11eb-9dbd-2072f03e5fb7.png)

# Solution

I consulted [a StackOverflow thread on fit-to-screen scaling algorithm](https://stackoverflow.com/questions/6565703/math-algorithm-fit-image-to-screen-retain-aspect-ratio) and adapted the logic to `docs/bundle.js`, where it handles canvas scaling:

```javascript
const cs = 95;
const wr = innerWidth/innerHeight; // Window ratio
const cr = canvasSize.x/canvasSize.y; // Canvas ratio
const unit = (wr >= cr) ? "vh" : "vw"; // Change the canvas unit according to the larger dimension of the window
const cw = (cr >= wr) ? cs : cs * canvasSize.x / canvasSize.y;
const ch = (wr >= cr) ? cs : cs * canvasSize.y / canvasSize.x;
canvas.style.width = `${cw}${unit}`;
canvas.style.height = `${ch}${unit}`;
```
Any canvas size should now be correctly scaled on any window size, guaranteeing at least one of the two dimensions being maximized.

This should not have any effect on your existing games, most of which are of 1:1 ratio.

# Side effect

The canvas is now using `vw` or `vh`, instead of `vmin` for its CSS `width` and `height` property, based on the dimensions of the window. There is no visible effect from the user's perspective.

# Style

I tried my best to keep the style consistent to your existing codes. Please feel free to refactor and/or rename variables. I'm happy to discuss any problem or issue you might have.

# PS

I'm also not sure if this is the best place to do so, in case `bundle.js` is the output of a repacking process somewhere I'm not aware of. Do let me know if it's the case, as I would like to understand this library better.