### PR TITLE
New option: isCapturingGameCanvasOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ l llll
 //   seed?: number; // Set the random number seed used to generate sounds.
 //
 //   isCapturing?: boolean; // Capture a screen by pressing 'c' key.
-//   isCapturingGameCanvasOnly?: boolean; // Additional setting for isCapturing, will omit the margins on two sides when enabled
+//   isCapturingGameCanvasOnly?: boolean; // Additional setting for isCapturing, will omit the margins on two sides when enabled.
 //   isDrawingParticleFront?: boolean; // Draw particles in front of the screen.
 //   isDrawingScoreFront?: boolean; // Draw the added score in front of the screen.
 //   isShowingScore?: boolean; // Show a score and a hi-score.

--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ l llll
 //   seed?: number; // Set the random number seed used to generate sounds.
 //
 //   isCapturing?: boolean; // Capture a screen by pressing 'c' key.
+//   isCapturingGameCanvasOnly?: boolean; // Additional setting for isCapturing, will omit the margins on two sides when enabled
 //   isDrawingParticleFront?: boolean; // Draw particles in front of the screen.
 //   isDrawingScoreFront?: boolean; // Draw the added score in front of the screen.
 //   isShowingScore?: boolean; // Show a score and a hi-score.

--- a/docs/bundle.d.ts
+++ b/docs/bundle.d.ts
@@ -12,6 +12,7 @@ declare type Options = {
   isPlayingBgm?: boolean;
   isSpeedingUpSound?: boolean;
   isCapturing?: boolean;
+  isCapturingGameCanvasOnly?: boolean;
   isShowingScore?: boolean;
   isShowingTime?: boolean;
   isReplayEnabled?: boolean;

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -1,6 +1,28 @@
 (function (exports, PIXI) {
   'use strict';
 
+  function _interopNamespace(e) {
+    if (e && e.__esModule) return e;
+    var n = Object.create(null);
+    if (e) {
+      Object.keys(e).forEach(function (k) {
+        if (k !== 'default') {
+          var d = Object.getOwnPropertyDescriptor(e, k);
+          Object.defineProperty(n, k, d.get ? d : {
+            enumerable: true,
+            get: function () {
+              return e[k];
+            }
+          });
+        }
+      });
+    }
+    n['default'] = e;
+    return Object.freeze(n);
+  }
+
+  var PIXI__namespace = /*#__PURE__*/_interopNamespace(PIXI);
+
   function clamp$1(v, low = 0, high = 1) {
       return Math.max(low, Math.min(v, high));
   }
@@ -216,7 +238,7 @@
       0x03a9f4,
       0x616161,
   ];
-  function init(isDarkColor) {
+  function init$8(isDarkColor) {
       const [wr, wb, wg] = getRgb(0, isDarkColor);
       values = fromEntities(colors.map((c, i) => {
           if (i < 1) {
@@ -942,7 +964,7 @@ l l l
 
   let hitBoxes;
   let tmpHitBoxes;
-  function clear() {
+  function clear$1() {
       hitBoxes = [];
       tmpHitBoxes = [];
   }
@@ -1023,7 +1045,7 @@ l l l
   let isCacheEnabled = false;
   let letterCanvas;
   let letterContext;
-  const defaultOptions = {
+  const defaultOptions$4 = {
       color: "black",
       backgroundColor: "transparent",
       rotation: 0,
@@ -1032,7 +1054,7 @@ l l l
       isCharacter: false,
       isCheckingCollision: false,
   };
-  function init$1() {
+  function init$7() {
       letterCanvas = document.createElement("canvas");
       letterCanvas.width = letterCanvas.height = letterSize;
       letterContext = letterCanvas.getContext("2d");
@@ -1136,7 +1158,7 @@ l l l
           const cachedImage = document.createElement("img");
           cachedImage.src = letterCanvas.toDataURL();
           if (theme.isUsingPixi) {
-              texture = PIXI.Texture.from(cachedImage);
+              texture = PIXI__namespace.Texture.from(cachedImage);
           }
           if (isCacheEnabled) {
               cachedImages[cacheIndex] = {
@@ -1200,7 +1222,7 @@ l l l
       const image = document.createElement("img");
       image.src = letterCanvas.toDataURL();
       if (theme.isUsingPixi) {
-          return { image, texture: PIXI.Texture.from(image) };
+          return { image, texture: PIXI__namespace.Texture.from(image) };
       }
       return { image };
   }
@@ -1248,12 +1270,12 @@ l l l
       return b;
   }
   function mergeDefaultOptions(_options) {
-      let options = Object.assign(Object.assign({}, defaultOptions), _options);
+      let options = Object.assign(Object.assign({}, defaultOptions$4), _options);
       if (_options.scale != null) {
-          options.scale = Object.assign(Object.assign({}, defaultOptions.scale), _options.scale);
+          options.scale = Object.assign(Object.assign({}, defaultOptions$4.scale), _options.scale);
       }
       if (_options.mirror != null) {
-          options.mirror = Object.assign(Object.assign({}, defaultOptions.mirror), _options.mirror);
+          options.mirror = Object.assign(Object.assign({}, defaultOptions$4.mirror), _options.mirror);
       }
       return options;
   }
@@ -1277,7 +1299,7 @@ void main(void) {
 }
 `;
   function getGridFilter(width, height) {
-      return new PIXI.Filter(undefined, gridFilterFragment, {
+      return new PIXI__namespace.Filter(undefined, gridFilterFragment, {
           width,
           height,
       });
@@ -1289,7 +1311,7 @@ void main(void) {
   let context;
   let graphics;
   const graphicsScale = 5;
-  let background = document.createElement("img");
+  document.createElement("img");
   let captureCanvas;
   let captureContext;
   let capturedCanvasScale = 1;
@@ -1299,7 +1321,7 @@ void main(void) {
   let isFilling = false;
   let theme;
   let crtFilter;
-  function init$2(_size, _bodyBackground, _viewBackground, isCapturing, _theme) {
+  function init$6(_size, _bodyBackground, _viewBackground, isCapturing, isCapturingGameCanvasOnly, _theme) {
       size.set(_size);
       theme = _theme;
       viewBackground = _viewBackground;
@@ -1329,18 +1351,18 @@ image-rendering: pixelated;
       canvasSize.set(size);
       if (theme.isUsingPixi) {
           canvasSize.mul(graphicsScale);
-          const app = new PIXI.Application({
+          const app = new PIXI__namespace.Application({
               width: canvasSize.x,
               height: canvasSize.y,
           });
           canvas = app.view;
-          graphics = new PIXI.Graphics();
+          graphics = new PIXI__namespace.Graphics();
           graphics.scale.x = graphics.scale.y = graphicsScale;
-          PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST;
+          PIXI__namespace.settings.SCALE_MODE = PIXI__namespace.SCALE_MODES.NEAREST;
           app.stage.addChild(graphics);
           graphics.filters = [];
           if (theme.name === "crt") {
-              graphics.filters.push((crtFilter = new PIXI.filters.CRTFilter({
+              graphics.filters.push((crtFilter = new PIXI__namespace.filters.CRTFilter({
                   vignettingAlpha: 0.7,
               })));
           }
@@ -1348,7 +1370,7 @@ image-rendering: pixelated;
               graphics.filters.push(getGridFilter(canvasSize.x, canvasSize.y));
           }
           if (theme.name === "pixel" || theme.name === "shapeDark") {
-              const bloomFilter = new PIXI.filters.AdvancedBloomFilter({
+              const bloomFilter = new PIXI__namespace.filters.AdvancedBloomFilter({
                   threshold: 0.1,
                   bloomScale: theme.name === "pixel" ? 1.5 : 1,
                   brightness: theme.name === "pixel" ? 1.5 : 1,
@@ -1376,30 +1398,52 @@ image-rendering: pixelated;
       const ch = wr >= cr ? cs : (cs * canvasSize.y) / canvasSize.x;
       canvas.style.width = `${cw}${unit}`;
       canvas.style.height = `${ch}${unit}`;
+      console.log(isCapturing);
+      console.log(isCapturingGameCanvasOnly);
       if (isCapturing) {
           captureCanvas = document.createElement("canvas");
-          if (canvasSize.x <= canvasSize.y * 2) {
-              captureCanvas.width = canvasSize.y * 2;
+          let optionCaptureScale;
+          if (isCapturingGameCanvasOnly) {
+              captureCanvas.width = canvasSize.x;
               captureCanvas.height = canvasSize.y;
+              capturedCanvasScale = (canvasSize.x > canvasSize.y)
+                  ? 400 / captureCanvas.width
+                  : 400 / captureCanvas.height;
+              captureCanvas.width = (canvasSize.x > canvasSize.y)
+                  ? 400
+                  : captureCanvas.width * capturedCanvasScale;
+              captureCanvas.height = (canvasSize.x > canvasSize.y)
+                  ? captureCanvas.height * capturedCanvasScale
+                  : 400;
+              optionCaptureScale = (canvasSize.x > canvasSize.y)
+                  ? Math.round(400 / captureCanvas.width)
+                  : Math.round(400 / captureCanvas.height);
           }
           else {
-              captureCanvas.width = canvasSize.x;
-              captureCanvas.height = canvasSize.x / 2;
-          }
-          if (captureCanvas.width > 400) {
-              capturedCanvasScale = 400 / captureCanvas.width;
-              captureCanvas.width = 400;
-              captureCanvas.height *= capturedCanvasScale;
+              if (canvasSize.x <= canvasSize.y * 2) {
+                  captureCanvas.width = canvasSize.y * 2;
+                  captureCanvas.height = canvasSize.y;
+              }
+              else {
+                  captureCanvas.width = canvasSize.x;
+                  captureCanvas.height = canvasSize.x / 2;
+              }
+              if (captureCanvas.width > 400) {
+                  capturedCanvasScale = 400 / captureCanvas.width;
+                  captureCanvas.width = 400;
+                  captureCanvas.height *= capturedCanvasScale;
+              }
+              optionCaptureScale = Math.round(400 / captureCanvas.width);
           }
           captureContext = captureCanvas.getContext("2d");
           captureContext.fillStyle = _bodyBackground;
           gcc.setOptions({
-              scale: Math.round(400 / captureCanvas.width),
+              scale: optionCaptureScale,
               capturingFps: 60,
           });
       }
   }
-  function clear$1() {
+  function clear() {
       if (theme.isUsingPixi) {
           graphics.clear();
           isFilling = false;
@@ -1459,7 +1503,7 @@ image-rendering: pixelated;
       }
       context.fillRect(x, y, width, height);
   }
-  function drawLine(x1, y1, x2, y2, thickness) {
+  function drawLine$1(x1, y1, x2, y2, thickness) {
       const cn = colorToNumber(currentColor);
       beginFillColor(cn);
       graphics.drawCircle(x1, y1, thickness * 0.5);
@@ -1475,7 +1519,7 @@ image-rendering: pixelated;
           endFill();
           graphics.beginTextureFill({
               texture: li.texture,
-              matrix: new PIXI.Matrix().translate(x, y),
+              matrix: new PIXI__namespace.Matrix().translate(x, y),
           });
           graphics.drawRect(x, y, width == null ? letterSize : width, height == null ? letterSize : height);
           beginFillColor(colorToNumber(currentColor));
@@ -1504,9 +1548,9 @@ image-rendering: pixelated;
       gcc.capture(captureCanvas);
   }
 
-  let isPressed = false;
-  let isJustPressed = false;
-  let isJustReleased = false;
+  let isPressed$2 = false;
+  let isJustPressed$2 = false;
+  let isJustReleased$2 = false;
   const codes = [
       "Escape",
       "Digit0",
@@ -1650,18 +1694,18 @@ image-rendering: pixelated;
       "BrowserBack"
   ];
   let code;
-  const defaultOptions$1 = {
+  const defaultOptions$3 = {
       onKeyDown: undefined
   };
-  let options$1;
+  let options$3;
   let isKeyPressing = false;
   let isKeyPressed = false;
   let isKeyReleased = false;
   let pressingCode = {};
   let pressedCode = {};
   let releasedCode = {};
-  function init$3(_options) {
-      options$1 = Object.assign(Object.assign({}, defaultOptions$1), _options);
+  function init$5(_options) {
+      options$3 = Object.assign(Object.assign({}, defaultOptions$3), _options);
       code = fromEntities(codes.map(c => [
           c,
           {
@@ -1673,8 +1717,8 @@ image-rendering: pixelated;
       document.addEventListener("keydown", e => {
           isKeyPressing = isKeyPressed = true;
           pressingCode[e.code] = pressedCode[e.code] = true;
-          if (options$1.onKeyDown != null) {
-              options$1.onKeyDown();
+          if (options$3.onKeyDown != null) {
+              options$3.onKeyDown();
           }
           if (e.code === "AltLeft" || e.code === "AltRight") {
               e.preventDefault();
@@ -1687,11 +1731,11 @@ image-rendering: pixelated;
           releasedCode[e.code] = true;
       });
   }
-  function update$1() {
-      isJustPressed = !isPressed && isKeyPressed;
-      isJustReleased = isPressed && isKeyReleased;
+  function update$6() {
+      isJustPressed$2 = !isPressed$2 && isKeyPressed;
+      isJustReleased$2 = isPressed$2 && isKeyReleased;
       isKeyPressed = isKeyReleased = false;
-      isPressed = isKeyPressing;
+      isPressed$2 = isKeyPressing;
       entries(code).forEach(([c, s]) => {
           s.isJustPressed = !s.isPressed && pressedCode[c];
           s.isJustReleased = s.isPressed && releasedCode[c];
@@ -1700,21 +1744,21 @@ image-rendering: pixelated;
       pressedCode = {};
       releasedCode = {};
   }
-  function clearJustPressed() {
-      isJustPressed = false;
-      isPressed = true;
+  function clearJustPressed$2() {
+      isJustPressed$2 = false;
+      isPressed$2 = true;
   }
 
   var keyboard = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    get isPressed () { return isPressed; },
-    get isJustPressed () { return isJustPressed; },
-    get isJustReleased () { return isJustReleased; },
+    get isPressed () { return isPressed$2; },
+    get isJustPressed () { return isJustPressed$2; },
+    get isJustReleased () { return isJustReleased$2; },
     codes: codes,
     get code () { return code; },
-    init: init$3,
-    update: update$1,
-    clearJustPressed: clearJustPressed
+    init: init$5,
+    update: update$6,
+    clearJustPressed: clearJustPressed$2
   });
 
   class Random {
@@ -1769,7 +1813,7 @@ image-rendering: pixelated;
       }
   }
 
-  const pos = new Vector();
+  const pos$1 = new Vector();
   let isPressed$1 = false;
   let isJustPressed$1 = false;
   let isJustReleased$1 = false;
@@ -1820,11 +1864,11 @@ image-rendering: pixelated;
           onUp();
       }, { passive: false });
   }
-  function update$2() {
-      calcPointerPos(cursorPos.x, cursorPos.y, pos);
-      if (options$2.isDebugMode && !pos.isInRect(0, 0, pixelSize.x, pixelSize.y)) {
+  function update$5() {
+      calcPointerPos(cursorPos.x, cursorPos.y, pos$1);
+      if (options$2.isDebugMode && !pos$1.isInRect(0, 0, pixelSize.x, pixelSize.y)) {
           updateDebug();
-          pos.set(debugPos);
+          pos$1.set(debugPos);
           isJustPressed$1 = !isPressed$1 && debugIsDown;
           isJustReleased$1 = isPressed$1 && !debugIsDown;
           isPressed$1 = debugIsDown;
@@ -1896,21 +1940,21 @@ image-rendering: pixelated;
 
   var pointer = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    pos: pos,
+    pos: pos$1,
     get isPressed () { return isPressed$1; },
     get isJustPressed () { return isJustPressed$1; },
     get isJustReleased () { return isJustReleased$1; },
     init: init$4,
-    update: update$2,
+    update: update$5,
     clearJustPressed: clearJustPressed$1
   });
 
-  let pos$1 = new Vector();
-  let isPressed$2 = false;
-  let isJustPressed$2 = false;
-  let isJustReleased$2 = false;
-  function init$5() {
-      init$3({
+  let pos = new Vector();
+  let isPressed = false;
+  let isJustPressed = false;
+  let isJustReleased = false;
+  function init$3() {
+      init$5({
           onKeyDown: sss.playEmpty,
       });
       init$4(canvas, size, {
@@ -1918,64 +1962,65 @@ image-rendering: pixelated;
           anchor: new Vector(0.5, 0.5),
       });
   }
-  function update$3() {
-      update$1();
-      update$2();
-      pos$1 = pos;
-      isPressed$2 = isPressed || isPressed$1;
-      isJustPressed$2 = isJustPressed || isJustPressed$1;
-      isJustReleased$2 = isJustReleased || isJustReleased$1;
+  function update$4() {
+      update$6();
+      update$5();
+      pos = pos$1;
+      isPressed = isPressed$2 || isPressed$1;
+      isJustPressed = isJustPressed$2 || isJustPressed$1;
+      isJustReleased = isJustReleased$2 || isJustReleased$1;
   }
-  function clearJustPressed$2() {
-      clearJustPressed();
+  function clearJustPressed() {
+      clearJustPressed$2();
       clearJustPressed$1();
   }
   function set(state) {
-      pos$1.set(state.pos);
-      isPressed$2 = state.isPressed;
-      isJustPressed$2 = state.isJustPressed;
-      isJustReleased$2 = state.isJustReleased;
+      pos.set(state.pos);
+      isPressed = state.isPressed;
+      isJustPressed = state.isJustPressed;
+      isJustReleased = state.isJustReleased;
   }
 
   var input$1 = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    get pos () { return pos$1; },
-    get isPressed () { return isPressed$2; },
-    get isJustPressed () { return isJustPressed$2; },
-    get isJustReleased () { return isJustReleased$2; },
-    init: init$5,
-    update: update$3,
-    clearJustPressed: clearJustPressed$2,
+    get pos () { return pos; },
+    get isPressed () { return isPressed; },
+    get isJustPressed () { return isJustPressed; },
+    get isJustReleased () { return isJustReleased; },
+    init: init$3,
+    update: update$4,
+    clearJustPressed: clearJustPressed,
     set: set
   });
 
   let lastFrameTime = 0;
   let _init;
-  let _update;
-  const defaultOptions$3 = {
+  let _update$1;
+  const defaultOptions$1 = {
       viewSize: { x: 126, y: 126 },
       bodyBackground: "#111",
       viewBackground: "black",
       isUsingVirtualPad: true,
       isFourWaysStick: false,
       isCapturing: false,
+      isCapturingGameCanvasOnly: false,
       theme: { name: "simple", isUsingPixi: false, isDarkColor: false },
   };
-  let options$3;
+  let options$1;
   let textCacheEnableTicks = 10;
-  function init$6(__init, __update, _options) {
+  function init$2(__init, __update, _options) {
       _init = __init;
-      _update = __update;
-      options$3 = Object.assign(Object.assign({}, defaultOptions$3), _options);
-      init(options$3.theme.isDarkColor);
-      init$2(options$3.viewSize, options$3.bodyBackground, options$3.viewBackground, options$3.isCapturing, options$3.theme);
-      init$5();
-      init$1();
+      _update$1 = __update;
+      options$1 = Object.assign(Object.assign({}, defaultOptions$1), _options);
+      init$8(options$1.theme.isDarkColor);
+      init$6(options$1.viewSize, options$1.bodyBackground, options$1.viewBackground, options$1.isCapturing, options$1.isCapturingGameCanvasOnly, options$1.theme);
+      init$3();
+      init$7();
       _init();
-      update$4();
+      update$3();
   }
-  function update$4() {
-      requestAnimationFrame(update$4);
+  function update$3() {
+      requestAnimationFrame(update$3);
       const now = window.performance.now();
       const timeSinceLast = now - lastFrameTime;
       if (timeSinceLast < 1000 / 60 - 5) {
@@ -1983,9 +2028,9 @@ image-rendering: pixelated;
       }
       lastFrameTime = now;
       sss.update();
-      update$3();
-      _update();
-      if (options$3.isCapturing) {
+      update$4();
+      _update$1();
+      if (options$1.isCapturing) {
           capture();
       }
       textCacheEnableTicks--;
@@ -2005,7 +2050,7 @@ image-rendering: pixelated;
           this.characterGrid = range(this.size.x).map(() => range(this.size.y).map(() => undefined));
       }
       print(str, _x, _y, _options = {}) {
-          const options = Object.assign(Object.assign({}, defaultOptions), _options);
+          const options = Object.assign(Object.assign({}, defaultOptions$4), _options);
           let x = Math.floor(_x);
           let y = Math.floor(_y);
           const bx = x;
@@ -2048,7 +2093,7 @@ image-rendering: pixelated;
           if (_x < 0 || _x >= this.size.x || _y < 0 || _y >= this.size.y) {
               return;
           }
-          const options = Object.assign(Object.assign({}, defaultOptions), _options);
+          const options = Object.assign(Object.assign({}, defaultOptions$4), _options);
           const x = Math.floor(_x);
           const y = Math.floor(_y);
           this.letterGrid[x][y] = char;
@@ -2118,29 +2163,29 @@ image-rendering: pixelated;
   }
 
   let particles;
-  const random = new Random();
-  function init$7() {
+  const random$1 = new Random();
+  function init$1() {
       particles = [];
   }
   function add(pos, count = 16, speed = 1, angle = 0, angleWidth = Math.PI * 2) {
       if (count < 1) {
-          if (random.get() > count) {
+          if (random$1.get() > count) {
               return;
           }
           count = 1;
       }
       for (let i = 0; i < count; i++) {
-          const a = angle + random.get(angleWidth) - angleWidth / 2;
+          const a = angle + random$1.get(angleWidth) - angleWidth / 2;
           const p = {
               pos: new Vector(pos),
-              vel: new Vector(speed * random.get(0.5, 1), 0).rotate(a),
+              vel: new Vector(speed * random$1.get(0.5, 1), 0).rotate(a),
               color: currentColor,
-              ticks: clamp(random.get(10, 20) * Math.sqrt(Math.abs(speed)), 10, 60),
+              ticks: clamp(random$1.get(10, 20) * Math.sqrt(Math.abs(speed)), 10, 60),
           };
           particles.push(p);
       }
   }
-  function update$5() {
+  function update$2() {
       saveCurrentColor();
       particles = particles.filter((p) => {
           p.ticks--;
@@ -2169,7 +2214,7 @@ image-rendering: pixelated;
           toggleGroup: [],
       };
   }
-  function update$6(button) {
+  function update$1(button) {
       const o = vec(input.pos).sub(button.pos);
       button.isHovered = o.isInRect(0, 0, button.size.x, button.size.y);
       if (input.isJustPressed && button.isHovered) {
@@ -2243,15 +2288,15 @@ image-rendering: pixelated;
           baseState: cloneDeep(baseState),
       });
   }
-  function rewind(random) {
+  function rewind$1(random) {
       const fs = frameStates.pop();
       const rs = fs.randomState;
       random.setSeed(rs.w, rs.x, rs.y, rs.z, 0);
       storedInput = {
-          pos: vec(pos$1),
-          isPressed: isPressed$2,
-          isJustPressed: isJustPressed$2,
-          isJustReleased: isJustReleased$2,
+          pos: vec(pos),
+          isPressed: isPressed,
+          isJustPressed: isJustPressed,
+          isJustReleased: isJustReleased,
       };
       set(record.inputs.pop());
       return fs;
@@ -2261,10 +2306,10 @@ image-rendering: pixelated;
       const rs = fs.randomState;
       random.setSeed(rs.w, rs.x, rs.y, rs.z, 0);
       storedInput = {
-          pos: vec(pos$1),
-          isPressed: isPressed$2,
-          isJustPressed: isJustPressed$2,
-          isJustReleased: isJustReleased$2,
+          pos: vec(pos),
+          isPressed: isPressed,
+          isJustPressed: isJustPressed,
+          isJustReleased: isJustReleased,
       };
       set(record.inputs[record.inputs.length - 1]);
       return fs;
@@ -2300,7 +2345,7 @@ image-rendering: pixelated;
       }
       const l = new Vector(length).rotate(rotate);
       const p = new Vector(x - l.x * centerPosRatio, y - l.y * centerPosRatio);
-      return drawLine$1(p, l, thickness);
+      return drawLine(p, l, thickness);
   }
   function line(x1, y1, x2 = 3, y2 = 3, thickness = 3) {
       const p = new Vector();
@@ -2343,7 +2388,7 @@ image-rendering: pixelated;
               }
           }
       }
-      return drawLine$1(p, p2.sub(p), thickness);
+      return drawLine(p, p2.sub(p), thickness);
   }
   function arc(centerX, centerY, radius, thickness, angleFrom, angleTo) {
       let centerPos = new Vector();
@@ -2391,7 +2436,7 @@ image-rendering: pixelated;
           a += ai;
           p2.set(radius).rotate(a).add(centerPos);
           o.set(p2).sub(p1);
-          const c = drawLine$1(p1, o, thickness, true);
+          const c = drawLine(p1, o, thickness, true);
           collision = Object.assign(Object.assign(Object.assign({}, collision), createShorthand(c.isColliding.rect)), { isColliding: {
                   rect: Object.assign(Object.assign({}, collision.isColliding.rect), c.isColliding.rect),
                   text: Object.assign(Object.assign({}, collision.isColliding.text), c.isColliding.text),
@@ -2438,10 +2483,10 @@ image-rendering: pixelated;
           }
       }
   }
-  function drawLine$1(p, l, thickness, isAddingToTmp = false) {
+  function drawLine(p, l, thickness, isAddingToTmp = false) {
       let isDrawing = true;
       if (theme.name === "shape" || theme.name === "shapeDark") {
-          drawLine(p.x, p.y, p.x + l.x, p.y + l.y, thickness);
+          drawLine$1(p.x, p.y, p.x + l.x, p.y + l.y, thickness);
       }
       const t = Math.floor(clamp$1(thickness, 3, 10));
       const lx = Math.abs(l.x);
@@ -2504,15 +2549,17 @@ image-rendering: pixelated;
   const round = Math.round;
   const ceil$1 = Math.ceil;
   exports.ticks = 0;
+  exports.difficulty = void 0;
   exports.score = 0;
+  exports.time = void 0;
   function rnd(lowOrHigh = 1, high) {
-      return random$1.get(lowOrHigh, high);
+      return random.get(lowOrHigh, high);
   }
   function rndi(lowOrHigh = 2, high) {
-      return random$1.getInt(lowOrHigh, high);
+      return random.getInt(lowOrHigh, high);
   }
   function rnds(lowOrHigh = 1, high) {
-      return random$1.get(lowOrHigh, high) * random$1.getPlusOrMinus();
+      return random.get(lowOrHigh, high) * random.getPlusOrMinus();
   }
   function end(_gameOverText = "GAME OVER") {
       gameOverText = _gameOverText;
@@ -2574,14 +2621,14 @@ image-rendering: pixelated;
   }
   function frameState(frameState) {
       if (isWaitingRewind) {
-          const rs = getLastFrameState(random$1);
+          const rs = getLastFrameState(random);
           const bs = rs.baseState;
           exports.score = bs.score;
           exports.ticks = bs.ticks;
           return cloneDeep(rs.gameState);
       }
       else if (isRewinding) {
-          const rs = rewind(random$1);
+          const rs = rewind$1(random);
           const bs = rs.baseState;
           exports.score = bs.score;
           exports.ticks = bs.ticks;
@@ -2593,11 +2640,11 @@ image-rendering: pixelated;
       }
       else if (state === "inGame") {
           const baseState = { score: exports.score, ticks: exports.ticks };
-          recordFrameState(frameState, baseState, random$1);
+          recordFrameState(frameState, baseState, random);
       }
       return frameState;
   }
-  function rewind$1() {
+  function rewind() {
       if (isRewinding) {
           return;
       }
@@ -2618,10 +2665,11 @@ image-rendering: pixelated;
       select: "s",
       lucky: "u",
   };
-  const defaultOptions$4 = {
+  const defaultOptions = {
       isPlayingBgm: false,
       isSpeedingUpSound: false,
       isCapturing: false,
+      isCapturingGameCanvasOnly: false,
       isShowingScore: true,
       isShowingTime: false,
       isReplayEnabled: false,
@@ -2634,7 +2682,7 @@ image-rendering: pixelated;
       theme: "simple",
   };
   const seedRandom = new Random();
-  const random$1 = new Random();
+  const random = new Random();
   const soundSpeedingUpInterval = 300;
   let state;
   let updateFunc = {
@@ -2669,10 +2717,10 @@ image-rendering: pixelated;
   function onLoad() {
       let opts;
       if (typeof options !== "undefined" && options != null) {
-          opts = Object.assign(Object.assign({}, defaultOptions$4), options);
+          opts = Object.assign(Object.assign({}, defaultOptions), options);
       }
       else {
-          opts = defaultOptions$4;
+          opts = defaultOptions;
       }
       const theme = {
           name: opts.theme,
@@ -2696,6 +2744,7 @@ image-rendering: pixelated;
       };
       seed = opts.seed;
       loopOptions.isCapturing = opts.isCapturing;
+      loopOptions.isCapturingGameCanvasOnly = opts.isCapturingGameCanvasOnly;
       loopOptions.viewSize = opts.viewSize;
       isPlayingBgm = opts.isPlayingBgm;
       isSpeedingUpSound = opts.isSpeedingUpSound;
@@ -2708,9 +2757,9 @@ image-rendering: pixelated;
       if (opts.isMinifying) {
           showMinifiedScript();
       }
-      init$6(init$8, _update$1, loopOptions);
+      init$2(init, _update, loopOptions);
   }
-  function init$8() {
+  function init() {
       if (typeof description !== "undefined" &&
           description != null &&
           description.trim().length > 0) {
@@ -2740,7 +2789,7 @@ image-rendering: pixelated;
           initTitle();
       }
   }
-  function _update$1() {
+  function _update() {
       exports.df = exports.difficulty = exports.ticks / 3600 + 1;
       exports.tc = exports.ticks;
       const prevScore = exports.score;
@@ -2748,12 +2797,12 @@ image-rendering: pixelated;
       exports.sc = exports.score;
       const prevSc = exports.sc;
       exports.inp = {
-          p: pos$1,
-          ip: isPressed$2,
-          ijp: isJustPressed$2,
-          ijr: isJustReleased$2,
+          p: pos,
+          ip: isPressed,
+          ijp: isJustPressed,
+          ijr: isJustReleased,
       };
-      clear();
+      clear$1();
       updateFunc[state]();
       if (theme.isUsingPixi) {
           endFill();
@@ -2773,7 +2822,7 @@ image-rendering: pixelated;
   function initInGame() {
       state = "inGame";
       exports.ticks = -1;
-      init$7();
+      init$1();
       const s = Math.floor(exports.score);
       if (s > hiScore) {
           hiScore = s;
@@ -2790,7 +2839,7 @@ image-rendering: pixelated;
           sss.playBgm();
       }
       const randomSeed = seedRandom.getInt(999999999);
-      random$1.setSeed(randomSeed);
+      random.setSeed(randomSeed);
       if (isReplayEnabled || isRewindEnabled) {
           initRecord(randomSeed);
           initFrameStates();
@@ -2799,24 +2848,24 @@ image-rendering: pixelated;
   }
   function updateInGame() {
       terminal.clear();
-      clear$1();
+      clear();
       if (!isDrawingParticleFront) {
-          update$5();
+          update$2();
       }
       if (!isDrawingScoreFront) {
           updateScoreBoards();
       }
       if (isReplayEnabled || isRewindEnabled) {
           recordInput({
-              pos: vec$1(pos$1),
-              isPressed: isPressed$2,
-              isJustPressed: isJustPressed$2,
-              isJustReleased: isJustReleased$2,
+              pos: vec$1(pos),
+              isPressed: isPressed,
+              isJustPressed: isJustPressed,
+              isJustReleased: isJustReleased,
           });
       }
       update();
       if (isDrawingParticleFront) {
-          update$5();
+          update$2();
       }
       if (isDrawingScoreFront) {
           updateScoreBoards();
@@ -2833,34 +2882,34 @@ image-rendering: pixelated;
   function initTitle() {
       state = "title";
       exports.ticks = -1;
-      init$7();
+      init$1();
       terminal.clear();
-      clear$1();
+      clear();
       if (isRecorded()) {
-          initReplay(random$1);
+          initReplay(random);
           isReplaying = true;
       }
   }
   function updateTitle() {
-      if (isJustPressed$2) {
+      if (isJustPressed) {
           initInGame();
           return;
       }
-      clear$1();
+      clear();
       if (isReplayEnabled && isRecorded()) {
           replayInput();
           exports.inp = {
-              p: pos$1,
-              ip: isPressed$2,
-              ijp: isJustPressed$2,
-              ijr: isJustReleased$2,
+              p: pos,
+              ip: isPressed,
+              ijp: isJustPressed,
+              ijr: isJustReleased,
           };
           if (!isDrawingParticleFront) {
-              update$5();
+              update$2();
           }
           update();
           if (isDrawingParticleFront) {
-              update$5();
+              update$2();
           }
           if (isSpeedingUpSound && exports.ticks % soundSpeedingUpInterval === 0) {
               sss.playInterval = 0.5 / sqrt(exports.difficulty);
@@ -2891,7 +2940,7 @@ image-rendering: pixelated;
   function initGameOver() {
       state = "gameOver";
       if (!isReplaying) {
-          clearJustPressed$2();
+          clearJustPressed();
       }
       exports.ticks = -1;
       drawGameOver();
@@ -2900,7 +2949,7 @@ image-rendering: pixelated;
       }
   }
   function updateGameOver() {
-      if ((isReplaying || exports.ticks > 20) && isJustPressed$2) {
+      if ((isReplaying || exports.ticks > 20) && isJustPressed) {
           initInGame();
       }
       else if (exports.ticks === (isReplayEnabled ? 120 : 300) && !isNoTitle) {
@@ -2937,19 +2986,19 @@ image-rendering: pixelated;
   }
   function updateRewind() {
       terminal.clear();
-      clear$1();
+      clear();
       update();
       drawScoreOrTime();
       restoreInput();
       if (isRewinding) {
           draw(rewindButton);
-          if (isFrameStateEmpty() || !isPressed$2) {
+          if (isFrameStateEmpty() || !isPressed) {
               stopRewind();
           }
       }
       else {
-          update$6(rewindButton);
-          update$6(giveUpButton);
+          update$1(rewindButton);
+          update$1(giveUpButton);
           if (rewindButton.isPressed) {
               isRewinding = true;
               isWaitingRewind = false;
@@ -2969,7 +3018,7 @@ image-rendering: pixelated;
   function stopRewind() {
       isRewinding = false;
       state = "inGame";
-      init$7();
+      init$1();
       if (isPlayingBgm) {
           sss.playBgm();
       }
@@ -3078,10 +3127,14 @@ image-rendering: pixelated;
           console.log(`${minifiedUpdateScript.length} letters`);
       });
   }
+  exports.inp = void 0;
   let clr = color$1;
   let ply = play;
   let tms = times;
   let rmv = remove;
+  exports.tc = void 0;
+  exports.df = void 0;
+  exports.sc = void 0;
   const tr = "transparent";
   const wh = "white";
   const rd = "red";
@@ -3186,7 +3239,7 @@ image-rendering: pixelated;
   exports.rd = rd;
   exports.rect = rect$1;
   exports.remove = remove;
-  exports.rewind = rewind$1;
+  exports.rewind = rewind;
   exports.rmv = rmv;
   exports.rnd = rnd;
   exports.rndi = rndi;
@@ -3200,10 +3253,12 @@ image-rendering: pixelated;
   exports.tms = tms;
   exports.tr = tr;
   exports.uc = uc;
-  exports.updateButton = update$6;
+  exports.updateButton = update$1;
   exports.vec = vec$1;
   exports.wh = wh;
   exports.wrap = wrap;
   exports.yl = yl;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
 
 }(this.window = this.window || {}, PIXI));

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -13,6 +13,7 @@ export type Options = {
   isUsingVirtualPad?: boolean;
   isFourWaysStick?: boolean;
   isCapturing?: boolean;
+  isCapturingGameCanvasOnly?: boolean;
   theme?: Theme;
 };
 
@@ -26,6 +27,7 @@ const defaultOptions: Options = {
   isUsingVirtualPad: true,
   isFourWaysStick: false,
   isCapturing: false,
+  isCapturingGameCanvasOnly: false,
   theme: { name: "simple", isUsingPixi: false, isDarkColor: false },
 };
 let options: Options;
@@ -45,6 +47,7 @@ export function init(
     options.bodyBackground,
     options.viewBackground,
     options.isCapturing,
+    options.isCapturingGameCanvasOnly,
     options.theme
   );
   input.init();

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,6 +183,7 @@ const defaultOptions: Options = {
   isPlayingBgm: false,
   isSpeedingUpSound: false,
   isCapturing: false,
+  isCapturingGameCanvasOnly: false,
   isShowingScore: true,
   isShowingTime: false,
   isReplayEnabled: false,
@@ -214,6 +215,7 @@ declare type Options = {
   isPlayingBgm?: boolean;
   isSpeedingUpSound?: boolean;
   isCapturing?: boolean;
+  isCapturingGameCanvasOnly?: boolean;
   isShowingScore?: boolean;
   isShowingTime?: boolean;
   isReplayEnabled?: boolean;
@@ -294,6 +296,7 @@ export function onLoad() {
   };
   seed = opts.seed;
   loopOptions.isCapturing = opts.isCapturing;
+  loopOptions.isCapturingGameCanvasOnly = opts.isCapturingGameCanvasOnly;
   loopOptions.viewSize = opts.viewSize;
   isPlayingBgm = opts.isPlayingBgm;
   isSpeedingUpSound = opts.isSpeedingUpSound;

--- a/src/view.ts
+++ b/src/view.ts
@@ -31,6 +31,7 @@ export function init(
   _bodyBackground: string,
   _viewBackground: Color,
   isCapturing: boolean,
+  isCapturingGameCanvasOnly: boolean,
   _theme: Theme
 ) {
   size.set(_size);
@@ -110,24 +111,45 @@ image-rendering: pixelated;
   const ch = wr >= cr ? cs : (cs * canvasSize.y) / canvasSize.x;
   canvas.style.width = `${cw}${unit}`;
   canvas.style.height = `${ch}${unit}`;
+  console.log(isCapturing);
+  console.log(isCapturingGameCanvasOnly);
   if (isCapturing) {
     captureCanvas = document.createElement("canvas");
-    if (canvasSize.x <= canvasSize.y * 2) {
-      captureCanvas.width = canvasSize.y * 2;
-      captureCanvas.height = canvasSize.y;
-    } else {
+    let optionCaptureScale;
+    if (isCapturingGameCanvasOnly) {
       captureCanvas.width = canvasSize.x;
-      captureCanvas.height = canvasSize.x / 2;
-    }
-    if (captureCanvas.width > 400) {
-      capturedCanvasScale = 400 / captureCanvas.width;
-      captureCanvas.width = 400;
-      captureCanvas.height *= capturedCanvasScale;
+      captureCanvas.height = canvasSize.y;
+      capturedCanvasScale = (canvasSize.x > canvasSize.y)
+        ? 400 / captureCanvas.width
+        : 400 / captureCanvas.height;
+      captureCanvas.width = (canvasSize.x > canvasSize.y)
+        ? 400
+        : captureCanvas.width * capturedCanvasScale;
+      captureCanvas.height = (canvasSize.x > canvasSize.y)
+        ? captureCanvas.height * capturedCanvasScale
+        : 400;
+      optionCaptureScale = (canvasSize.x > canvasSize.y)
+        ? Math.round(400 / captureCanvas.width)
+        : Math.round(400 / captureCanvas.height);
+    } else {
+      if (canvasSize.x <= canvasSize.y * 2) {
+          captureCanvas.width = canvasSize.y * 2;
+          captureCanvas.height = canvasSize.y;
+      } else {
+          captureCanvas.width = canvasSize.x;
+          captureCanvas.height = canvasSize.x / 2;
+      }
+      if (captureCanvas.width > 400) {
+          capturedCanvasScale = 400 / captureCanvas.width;
+          captureCanvas.width = 400;
+          captureCanvas.height *= capturedCanvasScale;
+      }
+      optionCaptureScale = Math.round(400 / captureCanvas.width);
     }
     captureContext = captureCanvas.getContext("2d");
     captureContext.fillStyle = _bodyBackground;
     gcc.setOptions({
-      scale: Math.round(400 / captureCanvas.width),
+      scale: optionCaptureScale,
       capturingFps: 60,
     });
   }


### PR DESCRIPTION
Implements a new property in `Options`, `isCapturingGameCanvasOnly`, which is parsed down to `loopOptions`, and finally, as the parameter for `view.init()`. Here it will be checked in order to use the appropriate canvas capturing size and logic.

If enabled, this setting will cause `gif-capturing-canvas` to record only the game canvas, omitting the side margins, which are used to optimise for gallery or Twitter posting.

Default option `defaultOptions.isCapturingGameCanvasOnly = false` is also added appropriately.

Do take note of the new scaling logic in `view.init()`. Please feel free to refactor:

```javascript
if (isCapturing) {
    captureCanvas = document.createElement("canvas");
    let optionCaptureScale;
    if (isCapturingGameCanvasOnly) {
      captureCanvas.width = canvasSize.x;
      captureCanvas.height = canvasSize.y;
      capturedCanvasScale = (canvasSize.x > canvasSize.y)
        ? 400 / captureCanvas.width
        : 400 / captureCanvas.height;
      captureCanvas.width = (canvasSize.x > canvasSize.y)
        ? 400
        : captureCanvas.width * capturedCanvasScale;
      captureCanvas.height = (canvasSize.x > canvasSize.y)
        ? captureCanvas.height * capturedCanvasScale
        : 400;
      optionCaptureScale = (canvasSize.x > canvasSize.y)
        ? Math.round(400 / captureCanvas.width)
        : Math.round(400 / captureCanvas.height);
    } else {
      if (canvasSize.x <= canvasSize.y * 2) {
          captureCanvas.width = canvasSize.y * 2;
          captureCanvas.height = canvasSize.y;
      } else {
          captureCanvas.width = canvasSize.x;
          captureCanvas.height = canvasSize.x / 2;
      }
      if (captureCanvas.width > 400) {
          capturedCanvasScale = 400 / captureCanvas.width;
          captureCanvas.width = 400;
          captureCanvas.height *= capturedCanvasScale;
      }
      optionCaptureScale = Math.round(400 / captureCanvas.width);
    }
    captureContext = captureCanvas.getContext("2d");
    captureContext.fillStyle = _bodyBackground;
    gcc.setOptions({
      scale: optionCaptureScale,
      capturingFps: 60,
    });
```

Needless to say, this option is only applicable once `isCapturing` also enabled.

Let me know if there is any problem.

PS: readme/documentation has been updated appropriately in a later commit.

# On nearest neighbour scaling

According to [this comment](https://github.com/processing/p5.js/issues/1845#issuecomment-365419633), `CanvasRenderingContext2D.imageSmoothingEnabled` [is real](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled). I have attempted to change this on `captureContext` in `view.init()` to no effect.

It is likely that this needs to be applied on `gif-capturing-canvas` itself. I will look into this and make the appropriate pull request for the package if I manage to do anything interesting.