### PR TITLE
Update readme regarding capturing canvas on pixiJS themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,10 +467,14 @@ l llll
 //   isCapturingGameCanvasOnly?: boolean;
 //    // Additional setting for isCapturing,
 //    // will omit the margins on two sides when enabled.
+//    // Not recommended for pixiJS themes due to complications with scale factor
 //   captureCanvasScale?: number;
 //    // Additional setting for isCapturingGameCanvasOnly,
 //    // set the scale of the output file, default: 1.
 //    // High scale (higher than 4) might lead to poor performance or crashing.
+//    // Will suffer poor performance and not be retained and when used on pixiJS
+//    // themes due to heavy post-processing and resizing. Value below 1 is
+//    // recommended in such cases (e.g. 0.4).
 //   isDrawingParticleFront?: boolean; // Draw particles in front of the screen.
 //   isDrawingScoreFront?: boolean; // Draw the added score in front of the screen.
 //   isShowingScore?: boolean; // Show a score and a hi-score.


### PR DESCRIPTION
I've recently had some unexpected experiences using the newly implemented `isCapturingGameCanvasOnly` and `captureCanvasScale` options on pixiJS themes. The scale factor was not retained and performance was poor, which I believe was caused by the resizing and post-processing done by pixiJS to achieved the visual effects.

The update added some note to the readme regarding this matter.

Let me know if you'd like to open an issue for future fix.