### PR TITLE
Fixed to update every 1/60 second on displays with refresh rate over 60

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -18,9 +18,12 @@ export type Options = {
   theme?: Theme;
 };
 
-let nextFrameTime = 0;
 let _init: () => void;
 let _update: () => void;
+const targetFps = 60;
+const practicalFps = targetFps * 0.8;
+const deltaTime = 1000 / practicalFps;
+let nextFrameTime = 0;
 const defaultOptions: Options = {
   viewSize: { x: 126, y: 126 },
   bodyBackground: "#111",
@@ -59,35 +62,16 @@ export function init(
   update();
 }
 
-let lastSpeedCheckTime = 0;
-let speedOverMsec = 0;
-function isOverSpeed(delta) {
-  const now = window.performance.now();
-  speedOverMsec += delta;
-  speedOverMsec -= now - lastSpeedCheckTime;
-  lastSpeedCheckTime = now;
-  if (speedOverMsec < -1000 || 1000 <= speedOverMsec) {
-    speedOverMsec = 0;
-  }
-  if (speedOverMsec >= 50) {
-    speedOverMsec -= delta;
-    return true;
-  } else {
-    false;
-  }
-}
 function update() {
   requestAnimationFrame(update);
   const now = window.performance.now();
-  if (now < nextFrameTime - 5) {
+  if (now < nextFrameTime - practicalFps / 12) {
     return;
   }
-  const delta = 1000 / 60;
-  nextFrameTime += delta;
-  if (nextFrameTime < now || nextFrameTime > now + delta) {
-    nextFrameTime = now + delta;
+  nextFrameTime += deltaTime;
+  if (nextFrameTime < now || nextFrameTime > now + deltaTime * 2) {
+    nextFrameTime = now + deltaTime;
   }
-  if (isOverSpeed(delta)) return;
   sss.update();
   input.update();
   _update();

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -61,10 +61,15 @@ export function init(
 
 function update() {
   requestAnimationFrame(update);
-  if (window.performance.now() < nextFrameTime) {
+  const now = window.performance.now();
+  if (now < nextFrameTime - 5) {
     return;
   }
-  nextFrameTime += 1000 / 60;
+  const delta = 1000 / 60;
+  nextFrameTime += delta;
+  if (nextFrameTime < now || nextFrameTime > now + delta) {
+    nextFrameTime = now + delta;
+  }
   sss.update();
   input.update();
   _update();

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -59,6 +59,23 @@ export function init(
   update();
 }
 
+let lastSpeedCheckTime = 0;
+let speedOverMsec = 0;
+function isOverSpeed(delta) {
+  const now = window.performance.now();
+  speedOverMsec += delta;
+  speedOverMsec -= now - lastSpeedCheckTime;
+  lastSpeedCheckTime = now;
+  if (speedOverMsec < -1000 || 1000 <= speedOverMsec) {
+    speedOverMsec = 0;
+  }
+  if (speedOverMsec >= 50) {
+    speedOverMsec -= delta;
+    return true;
+  } else {
+    false;
+  }
+}
 function update() {
   requestAnimationFrame(update);
   const now = window.performance.now();
@@ -70,6 +87,7 @@ function update() {
   if (nextFrameTime < now || nextFrameTime > now + delta) {
     nextFrameTime = now + delta;
   }
+  if (isOverSpeed(delta)) return;
   sss.update();
   input.update();
   _update();

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -18,7 +18,7 @@ export type Options = {
   theme?: Theme;
 };
 
-let lastFrameTime = 0;
+let nextFrameTime = 0;
 let _init: () => void;
 let _update: () => void;
 const defaultOptions: Options = {
@@ -61,12 +61,10 @@ export function init(
 
 function update() {
   requestAnimationFrame(update);
-  const now = window.performance.now();
-  const timeSinceLast = now - lastFrameTime;
-  if (timeSinceLast < 1000 / 60 - 5) {
+  if (window.performance.now() < nextFrameTime) {
     return;
   }
-  lastFrameTime = now;
+  nextFrameTime += 1000 / 60;
   sss.update();
   input.update();
   _update();

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -20,9 +20,8 @@ export type Options = {
 
 let _init: () => void;
 let _update: () => void;
-const targetFps = 60;
-const practicalFps = targetFps * 0.8;
-const deltaTime = 1000 / practicalFps;
+const targetFps = 68;
+const deltaTime = 1000 / targetFps;
 let nextFrameTime = 0;
 const defaultOptions: Options = {
   viewSize: { x: 126, y: 126 },
@@ -65,7 +64,7 @@ export function init(
 function update() {
   requestAnimationFrame(update);
   const now = window.performance.now();
-  if (now < nextFrameTime - practicalFps / 12) {
+  if (now < nextFrameTime - targetFps / 12) {
     return;
   }
   nextFrameTime += deltaTime;


### PR DESCRIPTION
I played a crisp-game-lib game on a display with a refresh rate of 144Hz.
Then I noticed that the game speed was 1.2 times faster.
I thought the reason was that the update process was dedicated to 60Hz displays.
I've fixed it to work with displays with a refresh rate of 144Hz or something else.